### PR TITLE
Add dotenv support, logging, CLI and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SHEET_ID=your_google_sheet_id
+GOOGLE_CREDS_JSON=/path/to/creds.json
+WORKSHEET=Birthdays
+TWILIO_ACCOUNT_SID=your_twilio_sid
+TWILIO_AUTH_TOKEN=your_twilio_token
+TWILIO_FROM_PHONE=+15555555555
+USER_PHONE=+15555555555
+MOCK_MODE=true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# chatgpt
+# Birthday Reminder Tool
+
+This repository contains a Python script (`birthday_reminder.py`) that checks a Google Sheet for upcoming birthdays and sends SMS notifications via Twilio.
+
+## Features
+
+- Reads a Google Sheet of names, birthdays, and phone numbers.
+- Sends a reminder 14 days before a birthday with a short list of gift ideas.
+- Automatically schedules a "Happy Birthday" message to be sent at 7:30 AM on the birthday.
+- Supports a mock mode for testing without sending real SMS.
+
+## Setup
+
+1. **Install Dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Environment Variables**
+   Copy `.env.example` to `.env` and fill in your credentials. The script uses [python-dotenv](https://github.com/theskumar/python-dotenv) to load these variables automatically.
+
+3. **Google Sheets Credentials**
+   - Create a Google service account and download the credentials JSON file.
+   - Share your Google Sheet with the service account email.
+
+4. **Running the Script**
+   - Run once immediately:
+     ```bash
+     python birthday_reminder.py --now
+     ```
+   - Or start the scheduler which checks daily at 7 AM:
+     ```bash
+     python birthday_reminder.py
+     ```
+
+5. **Tests**
+   ```bash
+   pytest -q
+   ```
+
+## Notes
+
+- The gift ideas list is static by default. You can modify the `fetch_gift_ideas` function to integrate with your preferred shopping API.
+- Network access may be required for Google Sheets and Twilio APIs.

--- a/birthday_reminder.py
+++ b/birthday_reminder.py
@@ -1,0 +1,150 @@
+import os
+import datetime
+import logging
+import argparse
+from typing import List
+
+from dotenv import load_dotenv
+
+try:
+    import gspread
+    from oauth2client.service_account import ServiceAccountCredentials
+except ImportError:
+    gspread = None  # placeholder if not installed
+    ServiceAccountCredentials = None
+
+try:
+    from twilio.rest import Client
+except ImportError:
+    Client = None
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+# Load environment variables from .env if available
+load_dotenv()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+# Static list of gift ideas used if network access is unavailable.
+STATIC_GIFT_IDEAS = [
+    "Gift idea 1 - https://example.com/product1",
+    "Gift idea 2 - https://example.com/product2",
+    "Gift idea 3 - https://example.com/product3",
+    "Gift idea 4 - https://example.com/product4",
+    "Gift idea 5 - https://example.com/product5",
+]
+
+MOCK_MODE = os.getenv("MOCK_MODE", "false").lower() == "true"
+
+def fetch_gift_ideas(person_name: str) -> List[str]:
+    """Return a list of gift idea strings."""
+    # In a real setup, this might query an online store's API.
+    # Here we return a static list due to environment limits.
+    return STATIC_GIFT_IDEAS
+
+
+def calculate_days_until(birthday: datetime.date, today: datetime.date | None = None) -> int:
+    """Return days until the next occurrence of birthday."""
+    if today is None:
+        today = datetime.date.today()
+    upcoming = birthday.replace(year=today.year)
+    if upcoming < today:
+        upcoming = upcoming.replace(year=today.year + 1)
+    return (upcoming - today).days
+
+
+def get_sheet_records() -> List[dict]:
+    """Fetch records from the Google Sheet."""
+    sheet_id = os.environ.get("SHEET_ID")
+    worksheet_name = os.environ.get("WORKSHEET", "Birthdays")
+    creds_path = os.environ.get("GOOGLE_CREDS_JSON")
+    if not sheet_id or not creds_path:
+        raise RuntimeError("SHEET_ID and GOOGLE_CREDS_JSON must be set")
+    if gspread is None or ServiceAccountCredentials is None:
+        raise RuntimeError("gspread is required to access Google Sheets")
+
+    scope = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
+    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
+    client = gspread.authorize(creds)
+    sheet = client.open_by_key(sheet_id)
+    worksheet = sheet.worksheet(worksheet_name)
+    return worksheet.get_all_records()
+
+
+def send_sms(to: str, body: str):
+    """Send an SMS message using Twilio or log in mock mode."""
+    if MOCK_MODE:
+        logger.info("[MOCK] SMS to %s: %s", to, body)
+        return
+    if Client is None:
+        raise RuntimeError("twilio is required to send SMS")
+    account_sid = os.environ.get("TWILIO_ACCOUNT_SID")
+    auth_token = os.environ.get("TWILIO_AUTH_TOKEN")
+    from_phone = os.environ.get("TWILIO_FROM_PHONE")
+    if not account_sid or not auth_token or not from_phone:
+        raise RuntimeError("Twilio credentials are not fully configured")
+
+    client = Client(account_sid, auth_token)
+    client.messages.create(to=to, from_=from_phone, body=body)
+
+
+def check_birthdays():
+    """Check the sheet for upcoming birthdays and send reminders."""
+    try:
+        records = get_sheet_records()
+    except Exception as exc:
+        logger.error("Error fetching sheet records: %s", exc)
+        return
+
+    now = datetime.datetime.now()
+    user_phone = os.environ.get("USER_PHONE")
+    for rec in records:
+        name = rec.get("name") or rec.get("Name")
+        birthday_str = rec.get("birthday") or rec.get("Birthday")
+        phone = rec.get("phone") or rec.get("Phone")
+        if not name or not birthday_str:
+            continue
+        try:
+            bday = datetime.datetime.strptime(birthday_str, "%Y-%m-%d")
+        except ValueError:
+            logger.error("Invalid date format for %s: %s", name, birthday_str)
+            continue
+
+        days_until = calculate_days_until(bday.date(), now.date())
+        upcoming = bday.replace(year=now.year)
+        if upcoming < now:
+            upcoming = upcoming.replace(year=now.year + 1)
+
+        if days_until == 14 and user_phone:
+            ideas = fetch_gift_ideas(name)
+            body = f"Reminder: {name}'s birthday is on {upcoming:%Y-%m-%d}.\n" + "\n".join(ideas)
+            try:
+                send_sms(user_phone, body)
+            except Exception as exc:
+                logger.error("Error sending SMS reminder: %s", exc)
+
+        if days_until == 0 and phone:
+            message = f"Happy Birthday, {name}!"
+            run_time = datetime.datetime.combine(upcoming.date(), datetime.time(7, 30))
+            scheduler.add_job(send_sms, "date", run_date=run_time, args=[phone, message])
+            logger.info("Scheduled birthday message for %s at %s", name, run_time)
+
+
+scheduler = BlockingScheduler()
+# Run check_birthdays every day at 7am
+scheduler.add_job(check_birthdays, "cron", hour=7, minute=0)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Birthday reminder")
+    parser.add_argument("--now", action="store_true", help="Run birthday check immediately and exit")
+    args = parser.parse_args()
+
+    if args.now:
+        check_birthdays()
+    else:
+        try:
+            scheduler.start()
+        except (KeyboardInterrupt, SystemExit):
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+gspread
+oauth2client
+twilio
+apscheduler
+python-dotenv
+pytest

--- a/tests/test_birthdays.py
+++ b/tests/test_birthdays.py
@@ -1,0 +1,19 @@
+import datetime
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from birthday_reminder import calculate_days_until
+
+def test_calculate_days_until_future():
+    today = datetime.date(2024, 6, 1)
+    birthday = datetime.date(1990, 6, 15)
+    assert calculate_days_until(birthday, today) == 14
+
+
+def test_calculate_days_until_next_year():
+    today = datetime.date(2024, 6, 16)
+    birthday = datetime.date(1990, 6, 15)
+    # Next occurrence will be next year
+    assert calculate_days_until(birthday, today) == 364

--- a/tests/test_gift_ideas.py
+++ b/tests/test_gift_ideas.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from birthday_reminder import fetch_gift_ideas
+
+def test_gift_ideas_count():
+    ideas = fetch_gift_ideas('Alice')
+    assert isinstance(ideas, list)
+    assert len(ideas) >= 5


### PR DESCRIPTION
## Summary
- refactor `birthday_reminder.py` to use `python-dotenv` and logging
- add mock mode and `--now` CLI flag
- provide `.env.example` and `requirements.txt`
- document setup and testing instructions in README
- add unit tests for gift ideas and birthday calculations

## Testing
- `python3 -m py_compile birthday_reminder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f72c625dc8321ab9d79416d54c6c9